### PR TITLE
Align MCP prompt IPC method

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -72,9 +72,9 @@ ipcMain.handle('stop-mcp', (_event, name: string) => {
 
 })
 
-ipcMain.handle('mcp:prompt', async (_event, prompt: string) => {
-  const proc = processes['memory']
-  if (!proc) return '❌ MCP memory no está corriendo.'
+ipcMain.handle('send-to-mcp', async (_event, { name, prompt }: { name: string; prompt: string }) => {
+  const proc = processes[name]
+  if (!proc) return `❌ MCP "${name}" no está corriendo.`
 
   return new Promise((resolve) => {
     let output = ''

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,7 +4,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Métodos para invocar procesos del backend
   startMCP: (name: string) => ipcRenderer.invoke('start-mcp', name),
   stopMCP: (name: string) => ipcRenderer.invoke('stop-mcp', name),
-  sendPrompt: (prompt: string) => ipcRenderer.invoke('mcp:prompt', prompt),
+  /**
+   * Send a prompt to a running MCP process.
+   *
+   * @param payload Object containing the target `name` and the `prompt` to send.
+   * @returns The response from the MCP process.
+   */
+  sendToMCP: (payload: { name: string; prompt: string }) =>
+    ipcRenderer.invoke('send-to-mcp', payload),
 
   // Escuchar eventos de estado de MCP
   onStatusUpdate: (callback: (status: { name: string; status: string }) => void) => {

--- a/src/components/MCPConsole.tsx
+++ b/src/components/MCPConsole.tsx
@@ -4,13 +4,6 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import AIModelSelector from './AIModelSelector'
 
-declare global {
-  interface Window {
-    api: {
-      sendToMCP: (prompt: string) => Promise<string>
-    }
-  }
-}
 
 interface Message {
   role: 'user' | 'mcp'
@@ -29,8 +22,8 @@ const MCPConsole: React.FC = () => {
     setPrompt('')
     setLoading(true)
 
-    try {
-      const res = await window.api.sendToMCP(prompt)
+      try {
+        const res = await window.electronAPI.sendToMCP({ name: 'memory', prompt })
       setMessages(prev => [...prev, { role: 'mcp', content: res }])
     } catch (err) {
       setMessages(prev => [

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -5,13 +5,13 @@ type MCPStatus = 'offline' | 'online' | 'starting' | 'error'
 
 declare global {
   interface Window {
-    electronAPI: {
-      startMCP: (name: string) => Promise<void>
-      stopMCP: (name: string) => Promise<void>
-      sendPrompt: (prompt: string) => Promise<void>
-      onStatusUpdate: (
-        callback: (status: { name: string; status: MCPStatus }) => void
-      ) => () => void
-    }
+      electronAPI: {
+        startMCP: (name: string) => Promise<void>
+        stopMCP: (name: string) => Promise<void>
+        sendToMCP: (payload: { name: string; prompt: string }) => Promise<string>
+        onStatusUpdate: (
+          callback: (status: { name: string; status: MCPStatus }) => void
+        ) => () => void
+      }
   }
 }


### PR DESCRIPTION
## Summary
- rename IPC call `sendPrompt` to `sendToMCP`
- update the global typings for `electronAPI`
- use `window.electronAPI.sendToMCP` in the console component
- pass `{ name, prompt }` to the Electron main process

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:mcp` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539f9140788322ae20c5107f75b3f0