### PR TITLE
Add model selection and send modelId to MCP

### DIFF
--- a/src/components/AIModelSelector.tsx
+++ b/src/components/AIModelSelector.tsx
@@ -10,7 +10,11 @@ const AI_MODELS = [
   { id: 'grok', label: 'Grok (xAI)' },
 ]
 
-const AIModelSelector = () => {
+interface AIModelSelectorProps {
+  onSelect: (id: string) => void
+}
+
+const AIModelSelector: React.FC<AIModelSelectorProps> = ({ onSelect }) => {
   const [selected, setSelected] = useState(AI_MODELS[0])
 
   return (
@@ -32,7 +36,10 @@ const AIModelSelector = () => {
           {AI_MODELS.map(model => (
             <DropdownMenu.Item
               key={model.id}
-              onSelect={() => setSelected(model)}
+              onSelect={() => {
+                setSelected(model)
+                onSelect(model.id)
+              }}
               className={`flex items-center justify-between w-full px-3 py-2 rounded-md cursor-pointer text-sm hover:bg-white/10 ${
                 selected.id === model.id ? 'bg-white/10' : ''
               }`}

--- a/src/components/MCPConsole.tsx
+++ b/src/components/MCPConsole.tsx
@@ -7,7 +7,7 @@ import AIModelSelector from './AIModelSelector'
 declare global {
   interface Window {
     api: {
-      sendToMCP: (prompt: string) => Promise<string>
+      sendToMCP: (payload: { name: string; prompt: string }) => Promise<string>
     }
   }
 }
@@ -19,6 +19,7 @@ interface Message {
 
 const MCPConsole: React.FC = () => {
   const [prompt, setPrompt] = useState('')
+  const [modelId, setModelId] = useState('openai-gpt4')
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(false)
   const bottomRef = useRef<HTMLDivElement | null>(null)
@@ -30,7 +31,7 @@ const MCPConsole: React.FC = () => {
     setLoading(true)
 
     try {
-      const res = await window.api.sendToMCP(prompt)
+      const res = await window.api.sendToMCP({ name: modelId, prompt })
       setMessages(prev => [...prev, { role: 'mcp', content: res }])
     } catch (err) {
       setMessages(prev => [
@@ -52,7 +53,7 @@ const MCPConsole: React.FC = () => {
   return (
     <div className="flex flex-col h-full w-full bg-black text-green-400 font-mono border border-green-500/30 rounded-xl shadow-inner shadow-green-500/10 p-4">
       <div className="flex-1 overflow-y-auto custom-scroll space-y-3 pr-2 mb-3">
-        <AIModelSelector />
+        <AIModelSelector onSelect={setModelId} />
         {messages.map((msg, idx) => (
           <div
             key={idx}


### PR DESCRIPTION
## Summary
- allow selecting AI model and expose `onSelect` callback
- keep selected model in `MCPConsole` and include `modelId` when sending prompts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68539f9297f08322b65030ae76855fd1