### PR TITLE
Add dotenv support

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,11 +4,14 @@ import fs from 'fs'
 import { spawn, ChildProcessWithoutNullStreams } from 'child_process'
 import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import dotenv from 'dotenv'
 
 
 // 🧠 Corrección para tener __dirname en ESM
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
+
+dotenv.config()
 
 let win: BrowserWindow
 const processes: Record<string, ChildProcessWithoutNullStreams> = {}
@@ -41,7 +44,10 @@ ipcMain.handle('start-mcp', (_event, name: string) => {
   const def = config.mcpServers[name]
   if (!def || processes[name]) return
 
-  const child = spawn(def.command, def.args, { shell: true })
+  const child = spawn(def.command, def.args, {
+    shell: true,
+    env: { ...process.env, ...(def.env || {}) }
+  })
   processes[name] = child
 
   win.webContents.send('mcp-status', { name, status: 'starting' })

--- a/scripts/test-all-mcps.ts
+++ b/scripts/test-all-mcps.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { spawn } from 'child_process'
 import path from 'path'
 import fs from 'fs'

--- a/scripts/test-mcp.ts
+++ b/scripts/test-mcp.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';


### PR DESCRIPTION
## Summary
- configure dotenv in `electron/main.ts`
- propagate `.env` variables in child processes
- preload dotenv in CLI test scripts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_6853a36e81c48322a63a1df3b006539f