### PR TITLE
Add environment setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your API keys
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -36,3 +36,22 @@ export default {
 2025-06-18 23:06:39.174 Electron[71655:42236000] Text input context does not respond to _valueForTIProperty:
 11:07:08 PM [vite] page reload mcp.config.json
 ```
+## Environment configuration
+
+The application expects a `.env` file in the project root containing API keys that MCP servers use to communicate with external providers.  A template is available in [`.env.example`](./.env.example).
+
+1. Copy the template:
+   ```bash
+   cp .env.example .env
+   ```
+2. Obtain your provider keys and fill in the values:
+   - **OpenAI** – Create a key at <https://platform.openai.com/account/api-keys> and set `OPENAI_API_KEY`.
+   - **Anthropic/Claude** – Create a key at <https://console.anthropic.com/> and set `ANTHROPIC_API_KEY`.
+
+## Running and using MCPs
+
+Start the application in development mode:
+```bash
+npm run dev
+```
+A window will open listing available MCP modules. Enable the one you want by toggling the switch next to its name. When the status shows `online`, select a model in the console panel, type a prompt and press **Enter** (or click **Enviar**) to send it to the running MCP.


### PR DESCRIPTION
## Summary
- add `.env.example` file
- ignore `.env`
- document how to fill the `.env` file with OpenAI and Anthropic keys
- explain how to run the MCP UI and send prompts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run test:mcp` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a3766ae483229628de16f7eeb491