### PR TITLE
Align model selector IDs with MCP config

### DIFF
--- a/src/components/AIModelSelector.tsx
+++ b/src/components/AIModelSelector.tsx
@@ -3,8 +3,9 @@ import { ChevronDown, Bot, Check } from 'lucide-react'
 import React, { useState } from 'react'
 
 const AI_MODELS = [
-  { id: 'openai-gpt4', label: 'OpenAI GPT-4' },
-  { id: 'claude-3', label: 'Anthropic Claude 3' },
+  // The `id` values must match the keys defined in `mcp.config.json`
+  { id: 'openai', label: 'OpenAI GPT-4' },
+  { id: 'anthropic', label: 'Anthropic Claude 3' },
   { id: 'mistral', label: 'Mistral 7B' },
   { id: 'llama', label: 'Meta LLaMA' },
   { id: 'grok', label: 'Grok (xAI)' },

--- a/src/components/MCPConsole.tsx
+++ b/src/components/MCPConsole.tsx
@@ -19,7 +19,8 @@ interface Message {
 
 const MCPConsole: React.FC = () => {
   const [prompt, setPrompt] = useState('')
-  const [modelId, setModelId] = useState('openai-gpt4')
+  // Default to the OpenAI server defined in `mcp.config.json`
+  const [modelId, setModelId] = useState('openai')
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(false)
   const bottomRef = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
## Summary
- update model IDs to match names used in `mcp.config.json`
- default console to the `openai` MCP id

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm run test:mcp` *(fails: tsx not found)*
- `npm run test:mcps` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a45abbd08322852aa080ebf40ef6