### PR TITLE
Add dotenv integration

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,9 @@ import fs from 'fs'
 import { spawn, ChildProcessWithoutNullStreams } from 'child_process'
 import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import dotenv from 'dotenv'
+
+dotenv.config()
 
 
 // 🧠 Corrección para tener __dirname en ESM
@@ -41,7 +44,10 @@ ipcMain.handle('start-mcp', (_event, name: string) => {
   const def = config.mcpServers[name]
   if (!def || processes[name]) return
 
-  const child = spawn(def.command, def.args, { shell: true })
+  const child = spawn(def.command, def.args, {
+    shell: true,
+    env: { ...process.env, ...(def.env || {}) },
+  })
   processes[name] = child
 
   win.webContents.send('mcp-status', { name, status: 'starting' })

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "tailwindcss": "^4.1.10",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@modelcontextprotocol/server-memory": "^2025.4.25",

--- a/scripts/test-all-mcps.ts
+++ b/scripts/test-all-mcps.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { spawn } from 'child_process'
 import path from 'path'
 import fs from 'fs'

--- a/scripts/test-mcp.ts
+++ b/scripts/test-mcp.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';


### PR DESCRIPTION
## Summary
- install `dotenv`
- configure dotenv at the start of `electron/main.ts`
- merge environment variables when starting MCPs
- load dotenv in MCP test scripts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6853a45706b48322a6c6e7ecd196756c